### PR TITLE
fix: docker-compose.yml - cpus 값을 string 으로 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: 2.0
+          cpus: '2.0'
           memory: 2048M
     volumes:
       - ./apps/producer/src:/app/apps/producer/src
@@ -26,7 +26,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: 2.0
+          cpus: '2.0'
           memory: 2048M
     volumes:
       - ./apps/consumer/src:/app/apps/consumer/src


### PR DESCRIPTION
```
$docker compose up -d
1 error(s) decoding:

* 'deploy.resources.limits.cpus' expected type 'string', got unconvertible type 'float64', value: '2'
```